### PR TITLE
Add error when public link token invalid

### DIFF
--- a/app/src/message/message-error.component.js
+++ b/app/src/message/message-error.component.js
@@ -1,0 +1,24 @@
+import { h } from "preact";
+import { useTranslation } from "react-i18next";
+
+export default function MessageError(props) {
+
+  const { t } = useTranslation();
+
+  const getError = (error) => {
+    switch (error?.type) {
+    case "invalid_token":
+      return t("invalid_token_error");
+    default:
+      return t("error");
+    }
+  };
+
+  return (
+    <div class="message">
+      <div class="message-body">
+        <p class="card-text">{getError(props.error)}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/src/message/message.component.js
+++ b/app/src/message/message.component.js
@@ -10,6 +10,7 @@ import { useEffect, useState, useRef, useReducer } from "preact/hooks";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useStoreon } from "storeon/preact";
+import MessageError from "./message-error.component.js";
 
 export default function Message(props) {
 
@@ -23,6 +24,7 @@ export default function Message(props) {
   const [edit, setEdit] = useState(false);
 
   const [message, setMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
   const messageRef = useRef(message);
   const setMessageRef = message => {
     messageRef.current = message;
@@ -82,10 +84,16 @@ export default function Message(props) {
       hydrateMessage(props.message);
     } else if (props?.token) {
       http.get(`/api/public/${props.token}`).then(m => {
+        if (!m) throw new Error("invalid_token");
         if (m?.files?.length) {
           setFiles(m?.files.map(f => ({id: f.id, status: "loading"})));
         }
         hydrateMessage(m);
+      }).catch (err => {
+        let error = {
+          "type": err?.message || "unknown",
+        };
+        setErrorMessage(error);
       });
     } else {
       http.get(`/api/messages/${props.id}`).then(m => {
@@ -204,6 +212,14 @@ export default function Message(props) {
       />
     );
   };
+
+  if (errorMessage?.type) {
+    return (
+      <Fragment>
+        <MessageError error={errorMessage} />
+      </Fragment>
+    );
+  }
 
   if (isRemoved || !message) {
     // placeholder (to be able to target it)

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -47,6 +47,7 @@
     "immediately": "Immediately",
     "in": "in",
     "Invalid login/password": "Invalid login and/or password",
+    "invalid_token_error": "This link is no longer valid.",
     "invitation_link": "Invitation link",
     "invitation_welcome": "Welcome on Zusam. Please sign up before joining the group.",
     "just_now": "Just now",


### PR DESCRIPTION
Adds a new message-error component that shows when loading a token failed (can be expanded later).

Shows that link is invalid if call to api/public/{token} fails. Otherwise gives generic error message.

Adds new term to en_US.json file.

Closes #80 