### PR TITLE
Environment variable to set default page + fixes

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -18,7 +18,7 @@ ALLOW_MESSAGE_REACTIONS="false"
 SHOW_GROUP_INVITATION_LINKS="true"
 
 # User defaults
-DEFAULT_PAGE="default_group"
+DEFAULT_PAGE="default_group" # "default_group" or "feed"
 
 # Task execution intervals in seconds
 CRON_CONVERT_IMAGES="60" # 1 minute

--- a/api/.env
+++ b/api/.env
@@ -17,6 +17,9 @@ ALLOW_MESSAGE_REACTIONS="false"
 # Can users invite?
 SHOW_GROUP_INVITATION_LINKS="true"
 
+# User defaults
+DEFAULT_PAGE="default_group"
+
 # Task execution intervals in seconds
 CRON_CONVERT_IMAGES="60" # 1 minute
 CRON_CONVERT_VIDEO="3600" # 1 hour

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
   allow.public.links: '%env(resolve:ALLOW_PUBLIC_LINKS)%'
   allow.message.reactions: '%env(resolve:ALLOW_MESSAGE_REACTIONS)%'
   show.group.invitation.links: '%env(resolve:SHOW_GROUP_INVITATION_LINKS)%'
+  default.page: '%env(resolve:DEFAULT_PAGE)%'
   idle_hours: '%env(resolve:IDLE_HOURS)%'
   video_conversion_threads: '%env(resolve:VIDEO_CONVERSION_THREADS)%'
   video_format_not_converted: '%env(resolve:VIDEO_FORMAT_NOT_CONVERTED)%'

--- a/api/src/Controller/Group/AddInvitedUser.php
+++ b/api/src/Controller/Group/AddInvitedUser.php
@@ -47,9 +47,10 @@ class AddInvitedUser extends ApiController
         if (empty($group)) {
             return new JsonResponse(['error' => 'Invalid invite key !'], Response::HTTP_BAD_REQUEST);
         }
-
-        $this->groupService->addUser($group, $this->getUser());
-
-        return new JsonResponse(['id' => $group->getId()], Response::HTTP_OK);
+        $user = $this->getUser();
+        if (!$user->getGroups()->contains($group)) {
+            $this->groupService->addUser($group, $user);
+        }
+        return new JsonResponse(['id' => $group->getId(), 'group' => $group->getId()], Response::HTTP_OK);
     }
 }

--- a/api/src/Controller/Group/AddInvitedUser.php
+++ b/api/src/Controller/Group/AddInvitedUser.php
@@ -4,6 +4,7 @@ namespace App\Controller\Group;
 
 use App\Controller\ApiController;
 use App\Entity\Group;
+use App\Entity\User;
 use App\Service\Group as GroupService;
 use Doctrine\ORM\EntityManagerInterface;
 use Nelmio\ApiDocBundle\Annotation\Security;
@@ -48,6 +49,11 @@ class AddInvitedUser extends ApiController
             return new JsonResponse(['error' => 'Invalid invite key !'], Response::HTTP_BAD_REQUEST);
         }
         $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return new JsonResponse(['error' => 'Unknown error'], Response::HTTP_BAD_REQUEST);
+        }
+
         if (!$user->getGroups()->contains($group)) {
             $this->groupService->addUser($group, $user);
         }

--- a/api/src/Controller/Group/AddInvitedUser.php
+++ b/api/src/Controller/Group/AddInvitedUser.php
@@ -57,6 +57,7 @@ class AddInvitedUser extends ApiController
         if (!$user->getGroups()->contains($group)) {
             $this->groupService->addUser($group, $user);
         }
+
         return new JsonResponse(['id' => $group->getId(), 'group' => $group->getId()], Response::HTTP_OK);
     }
 }

--- a/api/src/Controller/Security.php
+++ b/api/src/Controller/Security.php
@@ -148,7 +148,7 @@ class Security extends AbstractController
 
         $this->em->flush();
 
-        return $this->json(['api_key' => $user->getSecretKey()], Response::HTTP_OK);
+        return $this->json(['api_key' => $user->getSecretKey(), 'group' => $group->getId()], Response::HTTP_OK);
     }
 
     #[Route('/password-reset-mail', methods: ['POST'])]

--- a/api/src/Controller/Security.php
+++ b/api/src/Controller/Security.php
@@ -125,27 +125,28 @@ class Security extends AbstractController
             $user->setData(['mail' => $login]);
         }
 
-        // add the user to the group
-        $user->addGroup($group);
-        $group->addUser($user);
-        $this->em->persist($user);
-        $this->em->persist($group);
+        // If not already in the group, add the user
+        if (!$user->getGroups()->contains($group)) {
+            $user->addGroup($group);
+            $group->addUser($user);
+            $this->em->persist($user);
+            $this->em->persist($group);
+            
+            // notify users of the group
+            foreach ($group->getUsers() as $u) {
+                if ($u->getId() == $user->getId()) {
+                    continue;
+                }
 
-        // notify users of the group
-        foreach ($group->getUsers() as $u) {
-            if ($u->getId() == $user->getId()) {
-                continue;
+                $notif = new Notification();
+                $notif->setTarget($group->getId());
+                $notif->setOwner($u);
+                $notif->setFromUser($user);
+                $notif->setFromGroup($group);
+                $notif->setType(Notification::USER_JOINED_GROUP);
+                $this->em->persist($notif);
             }
-
-            $notif = new Notification();
-            $notif->setTarget($group->getId());
-            $notif->setOwner($u);
-            $notif->setFromUser($user);
-            $notif->setFromGroup($group);
-            $notif->setType(Notification::USER_JOINED_GROUP);
-            $this->em->persist($notif);
         }
-
         $this->em->flush();
 
         return $this->json(['api_key' => $user->getSecretKey(), 'group' => $group->getId()], Response::HTTP_OK);

--- a/api/src/Controller/Security.php
+++ b/api/src/Controller/Security.php
@@ -131,7 +131,7 @@ class Security extends AbstractController
             $group->addUser($user);
             $this->em->persist($user);
             $this->em->persist($group);
-            
+
             // notify users of the group
             foreach ($group->getUsers() as $u) {
                 if ($u->getId() == $user->getId()) {

--- a/api/src/Controller/User/Me.php
+++ b/api/src/Controller/User/Me.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Annotations as OA;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -33,13 +33,27 @@ class Me extends ApiController
      * @Security(name="api_key")
      */
     #[Route('/me', methods: ['GET'])]
-    public function index(): Response
+    public function index(): JsonResponse
     {
         $this->denyAccessUnlessGranted('ROLE_USER');
 
-        return new Response(
-            $this->serialize($this->getUser(), ['read_user', 'read_me']),
-            Response::HTTP_OK
+        $user = $this->getUser();
+        $user_norm = $this->normalize($user, ['read_user', 'read_me']);
+        
+        if (!isset($user_norm['data']['default_page'])) {
+            $user_norm['data']['default_page'] = $this->getParameter('default.page');
+        }
+
+        if (!isset($user_norm['data']['default_group'])) {
+            $groups = $user->getGroups();
+            if (!empty($groups) && !$groups->isEmpty()) {
+                $user_norm['data']['default_group'] = $groups->first()->getId();
+            }
+        }
+
+        return new JsonResponse(
+            $user_norm,
+            JsonResponse::HTTP_OK
         );
     }
 }

--- a/api/src/Controller/User/Me.php
+++ b/api/src/Controller/User/Me.php
@@ -3,6 +3,7 @@
 namespace App\Controller\User;
 
 use App\Controller\ApiController;
+use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
@@ -44,9 +45,9 @@ class Me extends ApiController
             $user_norm['data']['default_page'] = $this->getParameter('default.page');
         }
 
-        if (!isset($user_norm['data']['default_group'])) {
+        if (!isset($user_norm['data']['default_group']) && $user instanceof User) {
             $groups = $user->getGroups();
-            if (!empty($groups) && !$groups->isEmpty()) {
+            if (!$groups->isEmpty()) {
                 $user_norm['data']['default_group'] = $groups->first()->getId();
             }
         }

--- a/api/src/Controller/User/Me.php
+++ b/api/src/Controller/User/Me.php
@@ -40,7 +40,7 @@ class Me extends ApiController
 
         $user = $this->getUser();
         $user_norm = $this->normalize($user, ['read_user', 'read_me']);
-        
+
         if (!isset($user_norm['data']['default_page'])) {
             $user_norm['data']['default_page'] = $this->getParameter('default.page');
         }

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { http, api, me, notifications, bookmarks_utils, router } from "/src/core";
+import { http, api, me, notifications, bookmarks_utils, router, storage } from "/src/core";
 import {
   Login,
   Public,
@@ -41,6 +41,14 @@ function App() {
         });
     }
   };
+
+  function Logout() {
+    useEffect(() => {
+      storage.reset();
+    }, []);
+
+    return <Navigate replace to="/login" />;
+  }
 
   // initial load
   useEffect(() => {
@@ -106,7 +114,7 @@ function App() {
       <Route path="/signup" element={<Signup />} />
       <Route path="/stop-notification-emails/:userId/:token" element={<StopNotificationEmails />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/logout" element={<Navigate replace to="/login" />} />
+      <Route path="/logout" element={<Logout />} />
       <Route path="/:type/:id/settings" element={<Settings />} />
       <Route path="/bookmarks" element={<BookmarkBoard />} />
       <Route path="/create-group" element={<CreateGroup />} />

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -94,7 +94,7 @@ function App() {
     if (location.pathname.match(/^\/invitation/)) {
       if (user) {
         http.post(`/api/groups/invitation/${router.id}`, {}).catch(() => null).then(res => {
-          if (res) navigate("/");
+          if (res) navigate(res.group ? "/groups/" + res.group : "/");
         });
       } else {
         navigate(`/signup?inviteKey=${router.id}`);

--- a/app/src/outside/login.component.js
+++ b/app/src/outside/login.component.js
@@ -52,11 +52,7 @@ export default function Login() {
       if (res && res.api_key) {
         storage.set("apiKey", res.api_key).then(() => {
           me.update().then(user => {
-            let redirect = "/create-group";
-            if (user?.groups[0]) {
-              redirect = "/feed";
-            }
-            navigate(redirect);
+            navigate("/");
           });
         });
       } else if (res && res.message) {

--- a/app/src/outside/login.component.js
+++ b/app/src/outside/login.component.js
@@ -15,7 +15,6 @@ export default function Login() {
   useEffect(() => {
     // reroute if already logged in
     storage.get("apiKey").then(apiKey => apiKey && navigate("/"));
-    storage.reset();
 
     api.update().then(info => {
       if (info) setAllowEmails(info.allow_email);

--- a/app/src/outside/signup.component.js
+++ b/app/src/outside/signup.component.js
@@ -23,7 +23,7 @@ export default function Signup() {
       .then(res => {
         if (res && !res.message) {
           storage.set("apiKey", res.api_key);
-          setTimeout(() => navigate("/"), 100);
+          setTimeout(() => navigate(res.group ? "/groups/" + res.group : "/"), 100);
         } else {
           alert.add(t(res.message));
         }

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -49,7 +49,7 @@
     "Invalid login/password": "Invalid login and/or password",
     "invalid_token_error": "This link is no longer valid.",
     "invitation_link": "Invitation link",
-    "invitation_welcome": "Welcome on Zusam. Please sign up before joining the group.",
+    "invitation_welcome": "Welcome to Zusam. Please sign up before joining the group.",
     "just_now": "Just now",
     "lang": "language",
     "login_input": "Choose a login",


### PR DESCRIPTION
This PR includes a few changes:
- Adds environment variable that can be set in `config` to set the default value for "Default page" to default_page or feed
- Fixes logout not working
- Fix invite links to ensure it goes to the group the user was invited to after login/registration
- Fix some 500 errors that occurred during this process, e.g. user already a member of group. Now invite link will work if user is already a member, is already logged in, etc.

Resolves #171 