### PR TITLE
Change pin icon display location and color

### DIFF
--- a/app/src/message/message-preview.component.js
+++ b/app/src/message/message-preview.component.js
@@ -94,14 +94,6 @@ export default function MessagePreview(props) {
               ) : (
                 <div class="text-preview">{textPreview}</div>
               )}
-              {isPinned && !props.isFeed && (
-                <div class="pinned-icon">
-                  <FaIcon
-                    family={"regular"}
-                    icon={"thumbtack"}
-                  />
-                </div>
-              )}
             </Fragment>
           )}
         </div>
@@ -115,6 +107,14 @@ export default function MessagePreview(props) {
           >
             {data?.title || (<HumanTime timestamp={lastActivityDate} />)}
           </span>
+          {isPinned && !props.isFeed && (
+            <div class="pinned-icon">
+              <FaIcon
+                family={"regular"}
+                icon={"thumbtack"}
+              />
+            </div>
+          )}
           <span class="children">
             {children > 0 && (
               <span>

--- a/app/src/scss/_message.scss
+++ b/app/src/scss/_message.scss
@@ -423,10 +423,7 @@
     }
 
     .pinned-icon {
-      position: absolute;
-      top: 1px;
-      left: 5px;
-      color: #f7a71b;
+      color: $gray-600;
     }
   }
 }


### PR DESCRIPTION
I propose to change the pin icon location to the same information bar as the title of the post and the amounts of comments it got.  
It was previously displayed in the top left, over the message preview, which mean that we can't control its appearance over the user chosen background.

To mimic the rest of the information display, I changed the color from "zusam yellow" to a shade of gray.