### PR TITLE
Fix bugs: Settings page not updating on save, JSON showing in notifications if no post title to show

### DIFF
--- a/api/src/Service/Notification.php
+++ b/api/src/Service/Notification.php
@@ -59,7 +59,12 @@ class Notification
         }
 
         if (empty($title) && !empty($data['text'])) {
-            $title = $data['text'];
+            $parsed = json_decode($data['text'], true);
+            if (is_array($parsed) && isset($parsed['textOnly'])) {
+                $title = $parsed['textOnly'];
+            } else {
+                $title = $data['text'];
+            }
         }
 
         return $title;

--- a/app/src/settings/user-settings.component.js
+++ b/app/src/settings/user-settings.component.js
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import { lang, router, alert, http, util, storage } from "/src/core";
 import { useStore } from "@nanostores/preact";
-import { $me } from "/src/store/me.js";
+import { $me, updateMe } from "/src/store/me.js";
 import { useEffect, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -96,6 +96,7 @@ export default function UserSettings() {
       if (res["error"]) {
         alert.add(res["error"], "alert-danger");
       } else {
+        updateMe(res);
         setAlertMessage(t("settings_updated"));
         navigate(`${location.pathname}?alert=settings_updated`);
       }


### PR DESCRIPTION
This PR has two small changes that address the following:
- The settings page would revert to showing the old settings when saving even though the changes were saved
- The notifications would show QuillJS JSON if there was no title for the relevant post, due to the notification reverting to showing a preview of the post body and the  JSON existing in this body. Updated to identify this and use the textOnly field where it exists.

To my knowledge no issues were ever raised for these bugs.