### PR TITLE
Fix API key reset loop, fix bookmark page not loading if no bookmarks

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -102,7 +102,7 @@ function App() {
     }
 
     if (!router.isOutside() && !user) {
-      navigate("/login");
+      navigate("/logout");
     }
   });
 

--- a/app/src/pages/bookmark-board.component.js
+++ b/app/src/pages/bookmark-board.component.js
@@ -9,8 +9,7 @@ export default function BookmarkBoard() {
 
   const { t } = useTranslation();
   const bookmarks = useStore($bookmarks);
-
-  if (!bookmarks) {
+  if (bookmarks.length === 0) {
     return (
       <main>
         <Navbar />

--- a/app/src/settings/user-settings.component.js
+++ b/app/src/settings/user-settings.component.js
@@ -22,7 +22,7 @@ export default function UserSettings() {
 
   const resetApiKey = (event) => {
     event.preventDefault();
-    http.post(`/api/users/${me.id}/reset-api-key`, {}).then(() => router.logout()).catch(err => console.warn(err));
+    http.post(`/api/users/${me.id}/reset-api-key`, {}).then(() => navigate("/logout")).catch(err => console.warn(err));
   };
 
   const inputAvatar = () => {


### PR DESCRIPTION
The PR has a couple of tiny changes to solve two bugs I found recently.

- The API key reset is calling a logout function that doesn't exist, and having an invalid key redirects to /login which doesn't clear the invalid key. After I changed /login to redirect to the feed/default group, it now gets stuck in this loop (also updated this to direct to /logout so key is cleared)
- Fixed issue where the bookmarks page wouldn't load if you had no bookmarks

Closes #212 and #213 