### PR TITLE
Add confirmation modal popups to various functions

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { h, Fragment } from "preact";
 import { http, api, me, notifications, bookmarks_utils, router, storage } from "/src/core";
 import {
   Login,
@@ -20,6 +20,7 @@ import {
   useLocation,
 } from "react-router-dom";
 import { useEffect } from "preact/hooks";
+import ConfirmModal from "/src/misc/confirm-modal.component.js";
 
 function App() {
 
@@ -69,63 +70,68 @@ function App() {
     };
   });
 
-  me.fetch().then(user => {
-    if (user?._networkError) {
-      // Network is down — don't redirect, stay on current page
-      return;
-    }
+  useEffect(() => {
+    me.fetch().then(user => {
+      if (user?._networkError) {
+        // Network is down — don't redirect, stay on current page
+        return;
+      }
 
-    if (location.pathname === "/") {
-      let redirect = "/login";
-      if (user) {
-        redirect = "/create-group";
-        if (user?.groups[0]) {
-          const defaultPage = user?.data?.default_page || "default_group";
-          if (defaultPage === "default_group" && user?.data?.default_group) {
-            redirect = `/groups/${user.data.default_group}`;
-          } else {
-            redirect = "/feed";
+      if (location.pathname === "/") {
+        let redirect = "/login";
+        if (user) {
+          redirect = "/create-group";
+          if (user?.groups[0]) {
+            const defaultPage = user?.data?.default_page || "default_group";
+            if (defaultPage === "default_group" && user?.data?.default_group) {
+              redirect = `/groups/${user.data.default_group}`;
+            } else {
+              redirect = "/feed";
+            }
           }
         }
+        navigate(redirect);
       }
-      navigate(redirect);
-    }
 
-    if (location.pathname.match(/^\/invitation/)) {
-      if (user) {
-        http.post(`/api/groups/invitation/${router.id}`, {}).catch(() => null).then(res => {
-          if (res) navigate(res.group ? "/groups/" + res.group : "/");
-        });
-      } else {
-        navigate(`/signup?inviteKey=${router.id}`);
+      if (location.pathname.match(/^\/invitation/)) {
+        if (user) {
+          http.post(`/api/groups/invitation/${router.id}`, {}).catch(() => null).then(res => {
+            if (res) navigate(res.group ? "/groups/" + res.group : "/");
+          });
+        } else {
+          navigate(`/signup?inviteKey=${router.id}`);
+        }
       }
-    }
 
-    if (!router.isOutside() && !user) {
-      navigate("/login");
-    }
-  });
+      if (!router.isOutside() && !user) {
+        navigate("/logout");
+      }
+    });
+  }, []);
 
   return (
-    <Routes>
-      <Route path="/password-reset" element={<PasswordReset />} />
-      <Route path="/public/:token" element={<Public />} />
-      <Route path="/share" element={<Share />} />
-      <Route path="/signup" element={<Signup />} />
-      <Route path="/stop-notification-emails/:userId/:token" element={<StopNotificationEmails />} />
-      <Route path="/login" element={<Login />} />
-      <Route path="/logout" element={<Logout />} />
-      <Route path="/:type/:id/settings" element={<Settings />} />
-      <Route path="/bookmarks" element={<BookmarkBoard />} />
-      <Route path="/create-group" element={<CreateGroup />} />
-      <Route path="/groups/:id" element={<GroupBoard />} />
-      <Route path="/groups/:id/random" element={<RandomMessage />} />
-      <Route path="/groups/:id/search" element={<GroupSearchWrapper />} />
-      <Route path="/groups/:id/write" element={<GroupWriter />} />
-      <Route path="/feed" element={<FeedBoard />} />
-      <Route path="/messages/:id" element={<MessageParent />} />
-      <Route path="/messages/:id/:child_id" element={<MessageParent />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/password-reset" element={<PasswordReset />} />
+        <Route path="/public/:token" element={<Public />} />
+        <Route path="/share" element={<Share />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/stop-notification-emails/:userId/:token" element={<StopNotificationEmails />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/logout" element={<Logout />} />
+        <Route path="/:type/:id/settings" element={<Settings />} />
+        <Route path="/bookmarks" element={<BookmarkBoard />} />
+        <Route path="/create-group" element={<CreateGroup />} />
+        <Route path="/groups/:id" element={<GroupBoard />} />
+        <Route path="/groups/:id/random" element={<RandomMessage />} />
+        <Route path="/groups/:id/search" element={<GroupSearchWrapper />} />
+        <Route path="/groups/:id/write" element={<GroupWriter />} />
+        <Route path="/feed" element={<FeedBoard />} />
+        <Route path="/messages/:id" element={<MessageParent />} />
+        <Route path="/messages/:id/:child_id" element={<MessageParent />} />
+      </Routes>
+      <ConfirmModal />
+    </>
   );
 }
 

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -107,7 +107,7 @@ function App() {
         navigate("/logout");
       }
     });
-  }, []);
+  }, [location.pathname]);
 
   return (
     <>

--- a/app/src/message/message.component.js
+++ b/app/src/message/message.component.js
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useStore } from "@nanostores/preact";
 import { $me } from "/src/store/me.js";
 import MessageError from "./message-error.component.js";
-import { confirm } from "/src/store/confirm-modal.js";
+import { showConfirm } from "/src/store/confirm-modal.js";
 
 export default function Message(props) {
 
@@ -158,7 +158,7 @@ export default function Message(props) {
   const deleteMessage = async event => {
     event.preventDefault();
 
-    if (await confirm({
+    if (await showConfirm({
       title: t("ask_delete_message"),
       message: t("cant_be_undone"),
       confirmText: t("delete"),

--- a/app/src/message/message.component.js
+++ b/app/src/message/message.component.js
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useStore } from "@nanostores/preact";
 import { $me } from "/src/store/me.js";
 import MessageError from "./message-error.component.js";
+import { confirm } from "/src/store/confirm-modal.js";
 
 export default function Message(props) {
 
@@ -154,9 +155,16 @@ export default function Message(props) {
     return cn;
   };
 
-  const deleteMessage = event => {
+  const deleteMessage = async event => {
     event.preventDefault();
-    if (confirm(t("ask_delete_message"))) {
+
+    if (await confirm({
+      title: t("ask_delete_message"),
+      message: t("cant_be_undone"),
+      confirmText: t("delete"),
+      cancelText: t("cancel"),
+      variant: "danger"
+    })) {
       http.delete(`/api/messages/${props.id}`).then(() => {
         if (props.isChild) {
           setIsRemoved(true);

--- a/app/src/misc/confirm-modal.component.js
+++ b/app/src/misc/confirm-modal.component.js
@@ -1,0 +1,48 @@
+import { h, Fragment } from "preact";
+import { useStore } from "@nanostores/preact";
+import { $confirm, closeConfirm } from "../store/confirm-modal.js";
+
+export default function ConfirmModal() {
+  const state = useStore($confirm);
+
+  if (!state.open) return null;
+
+  return (
+    <>
+      <div
+        class="modal-backdrop fade show"
+        onClick={() => closeConfirm(false)}
+      ></div>
+
+      <div class="modal fade show d-block" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">{state.title}</h5>
+            </div>
+
+            <div class="modal-body">
+              <p>{state.message}</p>
+            </div>
+
+            <div class="modal-footer">
+              <button
+                class="btn btn-secondary"
+                onClick={() => closeConfirm(false)}
+              >
+                {state.cancelText}
+              </button>
+
+              <button
+                class={`btn btn-${state.variant}`}
+                onClick={() => closeConfirm(true)}
+              >
+                {state.confirmText}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -5,6 +5,7 @@ import { $me } from "/src/store/me.js";
 import { useEffect, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
+import { showConfirm } from "/src/store/confirm-modal.js";
 
 export default function GroupSettings() {
 
@@ -59,17 +60,25 @@ export default function GroupSettings() {
     }).catch(() => null);
   };
 
-  const leaveGroup = (event) => {
+  const leaveGroup = async (event) => {
     event.preventDefault();
-    if (me.data?.default_group == group.id) {
-      let user = {};
-      user.data = { default_group: me.groups[0].id };
-      http.put(`/api/users/${me.id}`, user).then(() => {
-        meService.fetch();
+    if (await showConfirm({
+      title: t("are_you_sure"),
+      message: t("you_will_need_invite"),
+      confirmText: t("quit_group"),
+      cancelText: t("cancel"),
+      variant: "warning"
+    })) {
+      if (me.data?.default_group == group.id) {
+        let user = {};
+        user.data = { default_group: me.groups[0].id };
+        http.put(`/api/users/${me.id}`, user).then(() => {
+          meService.fetch();
+          leave();
+        }).catch(err => console.warn(err));
+      } else {
         leave();
-      }).catch(err => console.warn(err));
-    } else {
-      leave();
+      }
     }
   };
 

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -41,7 +41,7 @@ export default function GroupSettings() {
       message: t("existing_invite_link_invalidated"),
       confirmText: t("reset_invitation_link"),
       cancelText: t("cancel"),
-      variant: "warning"
+      variant: "primary"
     })) {
       http
         .post(`/api/groups/${group.id}/reset-invite-key`, {})
@@ -75,7 +75,7 @@ export default function GroupSettings() {
       message: t("you_will_need_invite"),
       confirmText: t("quit_group"),
       cancelText: t("cancel"),
-      variant: "warning"
+      variant: "danger"
     })) {
       if (me.data?.default_group == group.id) {
         let user = {};

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -77,15 +77,23 @@ export default function GroupSettings() {
       cancelText: t("cancel"),
       variant: "danger"
     })) {
-      if (me.data?.default_group == group.id) {
-        let user = {};
-        user.data = { default_group: me.groups[0].id };
-        http.put(`/api/users/${me.id}`, user).then(() => {
-          meService.fetch();
+      if (group.users.length > 1 || await showConfirm({
+        title: t("are_you_sure"),
+        message: t("you_are_last_group_will_delete"),
+        confirmText: t("delete_group"),
+        cancelText: t("cancel"),
+        variant: "danger"
+      })) {
+        if (me.data?.default_group == group.id) {
+          let user = {};
+          user.data = { default_group: me.groups[0].id };
+          http.put(`/api/users/${me.id}`, user).then(() => {
+            meService.fetch();
+            leave();
+          }).catch(err => console.warn(err));
+        } else {
           leave();
-        }).catch(err => console.warn(err));
-      } else {
-        leave();
+        }
       }
     }
   };

--- a/app/src/settings/group-settings.component.js
+++ b/app/src/settings/group-settings.component.js
@@ -34,15 +34,23 @@ export default function GroupSettings() {
     setAlertMessage(t(router.getParam("alert")));
   }, []);
 
-  const resetInviteKey = (event) => {
+  const resetInviteKey = async (event) => {
     event.preventDefault();
-    http
-      .post(`/api/groups/${group.id}/reset-invite-key`, {})
-      .then(res => {
-        if (!res) return;
-        alert.add(t("group_updated"));
-        setInviteKey(res["inviteKey"]);
-      }).catch(() => null);
+    if (await showConfirm({
+      title: t("are_you_sure"),
+      message: t("existing_invite_link_invalidated"),
+      confirmText: t("reset_invitation_link"),
+      cancelText: t("cancel"),
+      variant: "warning"
+    })) {
+      http
+        .post(`/api/groups/${group.id}/reset-invite-key`, {})
+        .then(res => {
+          if (!res) return;
+          alert.add(t("group_updated"));
+          setInviteKey(res["inviteKey"]);
+        }).catch(() => null);
+    }
   };
 
   const updateSettings = (event) => {

--- a/app/src/settings/user-settings.component.js
+++ b/app/src/settings/user-settings.component.js
@@ -21,9 +21,17 @@ export default function UserSettings() {
     setAlertMessage(t(router.getParam("alert")));
   }, []);
 
-  const resetApiKey = (event) => {
+  const resetApiKey = async (event) => {
     event.preventDefault();
-    http.post(`/api/users/${me.id}/reset-api-key`, {}).then(() => router.logout()).catch(err => console.warn(err));
+    if (await showConfirm({
+      title: t("are_you_sure"),
+      message: t("you_will_be_logged_out"),
+      confirmText: t("reset"),
+      cancelText: t("cancel"),
+      variant: "warning"
+    })) {
+      http.post(`/api/users/${me.id}/reset-api-key`, {}).then(() => router.logout()).catch(err => console.warn(err));
+    }
   };
 
   const inputAvatar = () => {

--- a/app/src/settings/user-settings.component.js
+++ b/app/src/settings/user-settings.component.js
@@ -5,6 +5,7 @@ import { $me, updateMe } from "/src/store/me.js";
 import { useEffect, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
+import { showConfirm } from "/src/store/confirm-modal.js";
 
 export default function UserSettings() {
 
@@ -45,10 +46,15 @@ export default function UserSettings() {
     input.click();
   };
 
-  const destroyAccount = (event) => {
+  const destroyAccount = async (event) => {
     event.preventDefault();
-    let confirmDeletion = confirm(t("are_you_sure"));
-    if (confirmDeletion) {
+    if (await showConfirm({
+      title: t("are_you_sure"),
+      message: t("destroy_account_explain"),
+      confirmText: t("delete"),
+      cancelText: t("cancel"),
+      variant: "danger"
+    })) {
       http.delete(`/api/users/${me.id}`).then(() => {
         navigate("/logout");
       }).catch(err => console.warn(err));

--- a/app/src/settings/user-settings.component.js
+++ b/app/src/settings/user-settings.component.js
@@ -28,7 +28,7 @@ export default function UserSettings() {
       message: t("you_will_be_logged_out"),
       confirmText: t("reset"),
       cancelText: t("cancel"),
-      variant: "warning"
+      variant: "primary"
     })) {
       http.post(`/api/users/${me.id}/reset-api-key`, {}).then(() => router.logout()).catch(err => console.warn(err));
     }

--- a/app/src/store/confirm-modal.js
+++ b/app/src/store/confirm-modal.js
@@ -12,7 +12,7 @@ const DEFAULT_CONFIRM = {
 
 export const $confirm = atom(DEFAULT_CONFIRM);
 
-export function confirm(options) {
+export function showConfirm(options) {
   const opts = typeof options === "string" ? { message: options } : options;
 
   return new Promise((resolve) => {

--- a/app/src/store/confirm-modal.js
+++ b/app/src/store/confirm-modal.js
@@ -1,0 +1,32 @@
+import { atom } from "nanostores";
+
+const DEFAULT_CONFIRM = {
+  open: false,
+  title: "",
+  message: "",
+  confirmText: "",
+  cancelText: "",
+  variant: "danger", // Bootstrap button variant
+  resolve: null
+};
+
+export const $confirm = atom(DEFAULT_CONFIRM);
+
+export function confirm(options) {
+  const opts = typeof options === "string" ? { message: options } : options;
+
+  return new Promise((resolve) => {
+    $confirm.set({
+      ...DEFAULT_CONFIRM,
+      ...opts,
+      open: true,
+      resolve
+    });
+  });
+}
+
+export function closeConfirm(result) {
+  const { resolve } = $confirm.get();
+  $confirm.set(DEFAULT_CONFIRM);
+  if (resolve) resolve(result);
+}

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -85,6 +85,7 @@
     "replies_one": "{{count}} reply",
     "replies_other": "{{count}} replies",
     "reply": "reply",
+    "reset": "Reset",
     "reset_api_key": "Reset the API key (you will be disconnected)",
     "reset_invitation_link": "Reset invitation link",
     "reset_password_title": "Reset your password",
@@ -109,5 +110,6 @@
     "users": "users",
     "video_not_ready": "Video is not ready yet.",
     "weekly": "Weekly",
-    "you_have_no_bookmarks": "You have no bookmarks"
+    "you_have_no_bookmarks": "You have no bookmarks",
+    "you_will_be_logged_out": "You will be logged out."
 }

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -111,5 +111,6 @@
     "video_not_ready": "Video is not ready yet.",
     "weekly": "Weekly",
     "you_have_no_bookmarks": "You have no bookmarks",
-    "you_will_be_logged_out": "You will be logged out."
+    "you_will_be_logged_out": "You will be logged out.",
+    "you_will_need_invite": "You will need an invite to join again."
 }

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -33,6 +33,7 @@
     "error": "An error occurred",
     "error_new_message": "An error occurred while sending your message.",
     "error_upload": "An error occurred during the upload",
+    "existing_invite_link_invalidated": "The existing invite link will no longer work.",
     "feed": "Feed",
     "feed_group": "My Feed",
     "forgot_password": "Forgot your password?",

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -23,6 +23,7 @@
     "default_group": "Default group",
     "default_page": "Default page",
     "delete": "Delete",
+    "delete_group": "Delete group",
     "destroy_account": "Delete your account",
     "destroy_account_explain": "Once you delete your account, there is no going back. Please be certain.",
     "edit": "Edit",
@@ -111,6 +112,7 @@
     "users": "users",
     "video_not_ready": "Video is not ready yet.",
     "weekly": "Weekly",
+    "you_are_last_group_will_delete": "You are the only member of this group. If you leave, the group will be deleted.",
     "you_have_no_bookmarks": "You have no bookmarks",
     "you_will_be_logged_out": "You will be logged out.",
     "you_will_need_invite": "You will need an invite to join again."

--- a/translations/app/en_US.json
+++ b/translations/app/en_US.json
@@ -13,6 +13,7 @@
     "bookmarks": "bookmarks",
     "cancel": "Cancel",
     "cancel_write": "Do you really want to cancel writing a new message?",
+    "cant_be_undone": "This action can't be undone.",
     "changed_group_name": "changed the group's name",
     "confirm_password_placeholder": "confirm password",
     "connect": "Connect",


### PR DESCRIPTION
Added a reusable confirmation popup modal. Added to the following places:
- Delete message
- Reset API key
- Delete account
- Reset invite key
- Leave group

Leaving a group has a second confirm if you are the last user in the group, to confirm that leaving the group will delete it.

Closes #211 