### PR TITLE
Fix notifications when message deleted

### DIFF
--- a/api/src/Controller/Message/Delete.php
+++ b/api/src/Controller/Message/Delete.php
@@ -6,6 +6,7 @@ use App\Controller\ApiController;
 use App\Entity\Message;
 use App\Entity\Notification;
 use App\Entity\User;
+use App\Service\Message as MessageService;
 use Doctrine\ORM\EntityManagerInterface;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Annotations as OA;
@@ -20,14 +21,17 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
 class Delete extends ApiController
 {
     private $cache;
+    private MessageService $ms;
 
     public function __construct(
         EntityManagerInterface $em,
         SerializerInterface $serializer,
         TagAwareCacheInterface $cache,
+        MessageService $ms,
     ) {
         parent::__construct($em, $serializer);
         $this->cache = $cache;
+        $this->ms = $ms;
     }
 
     /**
@@ -55,20 +59,13 @@ class Delete extends ApiController
 
         $this->denyAccessUnlessGranted(new Expression('user == object.getAuthor()'), $message);
 
-        $notifications = $this->em->getRepository(Notification::class)->findByTarget($id);
-        foreach ($notifications as $n) {
-            $this->em->remove($n);
-        }
-
         $currentUser->setLastActivityDate(time());
         $this->em->persist($currentUser);
 
-        $this->em->remove($message);
+        $this->ms->delete($message);
 
         // Clear cache for the group
-        $this->cache->invalidateTags(['group_'.$message->getGroup()->getId()]);
-
-        $this->em->flush();
+        $this->cache->invalidateTags(['group_' . $message->getGroup()->getId()]);
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }

--- a/api/src/Controller/Message/Delete.php
+++ b/api/src/Controller/Message/Delete.php
@@ -4,7 +4,6 @@ namespace App\Controller\Message;
 
 use App\Controller\ApiController;
 use App\Entity\Message;
-use App\Entity\Notification;
 use App\Entity\User;
 use App\Service\Message as MessageService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -65,7 +64,7 @@ class Delete extends ApiController
         $this->ms->delete($message);
 
         // Clear cache for the group
-        $this->cache->invalidateTags(['group_' . $message->getGroup()->getId()]);
+        $this->cache->invalidateTags(['group_'.$message->getGroup()->getId()]);
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }

--- a/api/src/Controller/Notification/GetFromUser.php
+++ b/api/src/Controller/Notification/GetFromUser.php
@@ -4,7 +4,9 @@ namespace App\Controller\Notification;
 
 use App\Controller\ApiController;
 use App\Entity\User;
+use App\Service\Notification as NotificationService;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityNotFoundException;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Security;
 use OpenApi\Annotations as OA;
@@ -17,11 +19,15 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class GetFromUser extends ApiController
 {
+    private $notificationService;
+
     public function __construct(
         EntityManagerInterface $em,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        NotificationService $notificationService
     ) {
         parent::__construct($em, $serializer);
+        $this->notificationService = $notificationService;
     }
 
     /**
@@ -148,9 +154,17 @@ class GetFromUser extends ApiController
         $this->denyAccessUnlessGranted('ROLE_USER');
 
         $notifications = $currentUser->getNotifications($limit);
+        $normalized = [];
+        for ($i = 0; $i < sizeof($notifications); ++$i) {
+            try {
+                $normalized[] = $this->normalize($notifications[$i], ['read_notification']);
+            } catch (EntityNotFoundException $e) {
+                $this->notificationService->delete($notifications[$i]);
+            }
+        }
 
-        return new Response(
-            $this->serialize($notifications, ['read_notification']),
+        return new JsonResponse(
+            $normalized,
             Response::HTTP_OK,
         );
     }

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -236,7 +236,14 @@ class Notification extends ApiEntity
 
     public function getFromMessage(): ?Message
     {
-        return $this->fromMessage;
+        try {
+            // Force Doctrine to load the entity otherwise a non-existing entity doesn't throw
+            $this->fromMessage->getData();
+
+            return $this->fromMessage;
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 
     public function setFromMessage(Message $fromMessage): void

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -236,14 +236,7 @@ class Notification extends ApiEntity
 
     public function getFromMessage(): ?Message
     {
-        try {
-            // Force Doctrine to load the entity otherwise a non-existing entity doesn't throw
-            $this->fromMessage->getData();
-
-            return $this->fromMessage;
-        } catch (\Throwable $e) {
-            return null;
-        }
+        return $this->fromMessage;
     }
 
     public function setFromMessage(Message $fromMessage): void

--- a/api/src/Service/Message.php
+++ b/api/src/Service/Message.php
@@ -158,7 +158,7 @@ class Message
             $this->notificationService->delete($notification);
         }
 
-        $notifications = $this->em->getRepository(Notification::class)->find(['target' => $message->getId()]);
+        $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['target' => $message->getId()]);
         foreach ($notifications as $notification) {
             $this->notificationService->delete($notification);
         }

--- a/api/src/Service/Message.php
+++ b/api/src/Service/Message.php
@@ -150,4 +150,20 @@ class Message
 
         return ((int) $maxSortOrder) + 1;
     }
+
+    public function delete(MessageEntity $message)
+    {
+        $notifications = $this->em->getRepository(NotificationEntity::class)->findBy(['fromMessage' => $message]);
+        foreach ($notifications as $notification) {
+            $this->notificationService->delete($notification);
+        }
+
+        $notifications = $this->em->getRepository(Notification::class)->find(['target' => $message->getId()]);
+        foreach ($notifications as $notification) {
+            $this->notificationService->delete($notification);
+        }
+
+        $this->em->remove($message);
+        $this->em->flush();
+    }
 }

--- a/api/tests/Api/NotificationApiTest.php
+++ b/api/tests/Api/NotificationApiTest.php
@@ -50,7 +50,19 @@ class NotificationApiTest extends BaseApiTestCase
             $message
         );
 
-        // Delete the message - to test that this doesn't break notifications
+        // Create a second one that should be valid
+        $message = $this->createMessage($group, $author);
+
+        $notificationService->create(
+            Notification::NEW_MESSAGE,
+            $message->getId(),
+            $recipient,
+            $author,
+            $group,
+            $message
+        );
+
+        // Delete the first message - to test that this doesn't break notifications
         $messageRef = $em->getReference(Message::class, $message->getId());
         $em->remove($messageRef);
         $em->flush();
@@ -62,12 +74,13 @@ class NotificationApiTest extends BaseApiTestCase
         $this->apiKey = $data['api_key'];
 
         // Actual test that the endpoint still works
-        $response = $this->apiRequestWithAuth('GET', '/me/notifications');
+        $response = $this->apiRequestWithAuth('GET', '/me/notifications/21');
 
         $this->assertResponseIsSuccessful();
 
         $data = json_decode($response->getContent(), true);
 
+        // Second notification should still exist
         $this->assertNotEmpty($data);
     }
 

--- a/api/tests/Api/NotificationApiTest.php
+++ b/api/tests/Api/NotificationApiTest.php
@@ -3,6 +3,8 @@
 namespace App\Tests\Api;
 
 use App\Entity\Notification;
+use App\Entity\Message;
+use \App\Service\Notification as NotificationService;
 
 class NotificationApiTest extends BaseApiTestCase
 {
@@ -16,6 +18,57 @@ class NotificationApiTest extends BaseApiTestCase
         $this->assertEquals('notification', $data['entityType']);
         $this->assertEquals('global_notification', $data['type']);
         $this->assertEquals("Test Notification 0", $data['data']['text']);
+    }
+
+    public function testGetUserNotificationsWhenMessageDeleted(): void
+    {
+        $em = $this->getEntityManager();
+
+        // Setup users and add them to a group
+        $author = $this->getTestUser();
+        $recipient = $this->getOtherUser();
+
+        $group = $this->createGroup();
+        $group->addUser($author);
+        $group->addUser($recipient);
+        $author->addGroup($group);
+        $recipient->addGroup($group);
+
+        $em->persist($group);
+        $em->flush();
+
+        // Create a message and a related notification for the other user
+        $message = $this->createMessage($group, $author);
+        $notificationService = self::getContainer()->get(NotificationService::class);
+
+        $notificationService->create(
+            Notification::NEW_MESSAGE,
+            $message->getId(),
+            $recipient,
+            $author,
+            $group,
+            $message
+        );
+
+        // Delete the message - to test that this doesn't break notifications
+        $messageRef = $em->getReference(Message::class, $message->getId());
+        $em->remove($messageRef);
+        $em->flush();
+        $em->clear();
+
+        // Log in as the recipient to test their notifications still work after deletion of message
+        $response = $this->login($recipient->getLogin(), 'zusam');
+        $data = json_decode($response->getContent(), true);
+        $this->apiKey = $data['api_key'];
+
+        // Actual test that the endpoint still works
+        $response = $this->apiRequestWithAuth('GET', '/me/notifications');
+
+        $this->assertResponseIsSuccessful();
+
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertNotEmpty($data);
     }
 
     public function testEditUserNotification(): void

--- a/app/src/core/notifications.js
+++ b/app/src/core/notifications.js
@@ -21,7 +21,7 @@ const notifications = {
       return list.filter(n => !n.read).some(
         n =>
           notifications.matchNotification(n, id) ||
-          (n.type == "new_comment" && n.fromMessage.id === id)
+          (n.type == "new_comment" && n.fromMessage?.id === id)
       );
     }
     return false;

--- a/app/src/pages/notification.component.js
+++ b/app/src/pages/notification.component.js
@@ -125,7 +125,9 @@ export default function Notification(props) {
   useEffect(() => {
     http.get(`/api/notifications/${props.id}`, false, 100).then(n => {
       if (n) {
-        setTarget(getTarget(n, n.fromMessage?.id));
+        if (n?.fromMessage?.id) {
+          setTarget(getTarget(n, n.fromMessage.id));
+        }
         setAction(getAction(n));
         setTitle(n.title);
         if (n?.fromUser?.id) {


### PR DESCRIPTION
I found that when deleting a message, it can cause notifications to break due to the inability to serialise the notification object. This is related to #113 but that was focused on a user being deleted.

This PR relates to a message being deleted, and does a few things:
- Refactors message deletion a little to align notification deletion with the pattern used in #113 and adds section to delete notifications with the message in $fromMessage.
- Add section in Notification $fromMessage getter to stop it failing if the message doesn't exist
- UI tweak to handle no fromMessage value
- Added an API test to check that the notification endpoint doesn't return 500 in this scenario