### PR TITLE
Allow configuring email from address

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -88,7 +88,7 @@ dir_bots="%kernel.project_dir%/../data/bots"
 
 # Email settings
 ALLOW_EMAIL="false"
-MAILER_FROM="noreply@example.com"
+MAILER_FROM="noreply@%domain%"
 
 ###> symfony/mailer ###
 # https://symfony.com/doc/current/mailer.html

--- a/api/.env
+++ b/api/.env
@@ -86,8 +86,9 @@ dir_files="%kernel.project_dir%/../data/files"
 dir_cache="%kernel.project_dir%/../data/cache"
 dir_bots="%kernel.project_dir%/../data/bots"
 
-# Should we allow mails to be sent ?
+# Email settings
 ALLOW_EMAIL="false"
+MAILER_FROM="noreply@example.com"
 
 ###> symfony/mailer ###
 # https://symfony.com/doc/current/mailer.html

--- a/api/config/packages/mailer.yaml
+++ b/api/config/packages/mailer.yaml
@@ -2,4 +2,4 @@ framework:
   mailer:
     dsn: '%env(MAILER_DSN)%'
     headers:
-      From: '%env(MAILER_FROM)%'
+      From: '%env(resolve:MAILER_FROM)%'

--- a/api/config/packages/mailer.yaml
+++ b/api/config/packages/mailer.yaml
@@ -1,3 +1,5 @@
 framework:
   mailer:
     dsn: '%env(MAILER_DSN)%'
+    headers:
+      From: '%env(MAILER_FROM)%'

--- a/api/src/Service/Mailer.php
+++ b/api/src/Service/Mailer.php
@@ -63,7 +63,6 @@ class Mailer
         try {
             $email = new TemplatedEmail()
                 ->subject($this->translator->trans('notification.email.subject'))
-                ->from('noreply@'.$this->domain)
                 ->to($user->getLogin())
                 ->locale($lang)
                 ->text(
@@ -114,7 +113,6 @@ class Mailer
         try {
             $email = new TemplatedEmail()
                 ->subject($this->translator->trans('password.reset.email.subject'))
-                ->from('noreply@'.$this->domain)
                 ->to($user->getLogin())
                 ->locale($lang)
                 ->text(


### PR DESCRIPTION
This PR adds a .env config option that is fed into the symfony configuration to set the from address.

Previously the from address was hard coded as noreply@DOMAIN, and was set at the time the email was sent. Now this is set in the mailer config and is configurable using the MAILER_FROM environment variable.

The default value will use the noreply@DOMAIN format in order to maintain backwards compatibility.

Closes #208