### PR TITLE
Use more specific error messages on login page

### DIFF
--- a/app/src/outside/login.component.js
+++ b/app/src/outside/login.component.js
@@ -47,7 +47,7 @@ export default function Login() {
     let login = document.getElementById("login").value || "";
     login.toLowerCase();
     const password = document.getElementById("password").value;
-    http.post("/api/login", {login, password}).then(res => {
+    http.post("/api/login", { login, password }).then(res => {
       setSending(false);
       if (res && res.api_key) {
         storage.set("apiKey", res.api_key).then(() => {
@@ -60,9 +60,9 @@ export default function Login() {
       } else {
         alert.add(t("error"), "alert-danger");
       }
-    }).catch(() => {
+    }).catch((e) => {
       setSending(false);
-      alert.add(t("error"), "alert-danger");
+      alert.add(t(e.message), "alert-danger");
     });
   };
 


### PR DESCRIPTION
Very small change here to show specific error messages for the following scenarios:
- No login entered
- No password entered
- Login and password do not match account record

This change is possible following previous changes to the http.js code in #218  to allow the message to flow through to the frontend.

Note that the actual messages used already existed in the translation files, presumably this broke at some point in the past.